### PR TITLE
Fix TERM=screen-256 flight info rendering issue

### DIFF
--- a/dist/opt/flight/libexec/commands/info
+++ b/dist/opt/flight/libexec/commands/info
@@ -55,7 +55,16 @@ setup() {
 emit_doc() {
   bold="$(tput bold)"
   green="$(tput setaf 2)"
-  clr="$(tput sgr0)"
+
+  # 'less' has special handling for ANSI control sequences so it "just works".
+  # This causes 'tput sgr0' to render incorrectly in some TERM settings.
+  # Instead, the default SGR ANSI escape sequcence can be used
+  if [[ "$PAGER" == "less" ]] || [[ -z "$PAGER" ]] ; then
+    clr=$(printf "\E[;10m")
+  else
+    clr="$(tput sgr0)"
+  fi
+
   if [[ $TERM =~ "256color" ]]; then
     white="$(tput setaf 7)"
     bgblue="$(tput setab 68)"


### PR DESCRIPTION
The 'srg0' setting does not work with `less -FRX` for all settings.

This is particularly important for screen-256 color which uses
"shift-in" to control font changes. This however confuses less -FRX
causing the rendering issue.

Instead the default SRG can be manually triggered with: \E[;10m

NOTE: The original handling is still required for "dum" (smarter?)
pagers such as 'more'.