### PR TITLE
Fix `config get` exit status for empty settings

### DIFF
--- a/dist/opt/flight/libexec/commands/config
+++ b/dist/opt/flight/libexec/commands/config
@@ -1,7 +1,7 @@
 : '
 : NAME: config
 : SYNOPSIS: Configure a global HPC environment setting
-: VERSION: 1.1.0
+: VERSION: 2.0.0
 : ROOT: true
 : '
 #==============================================================================

--- a/dist/opt/flight/libexec/flight-starter/config
+++ b/dist/opt/flight/libexec/flight-starter/config
@@ -37,7 +37,7 @@ rescue LoadError
   nil
 end
 
-VERSION = '1.1.0'
+VERSION = '2.0.0'
 PROGRAM_NAME = ENV.fetch('FLIGHT_PROGRAM_NAME','config')
 UNKNOWN_SETTING = {}.freeze
 
@@ -56,6 +56,10 @@ Commands:
   get                  Get a value
   list                 List configured values
   set                  Set a value
+
+Global options:
+
+  --version            Display version information
 
 For more help on a particular command run:
   #{PROGRAM_NAME} help COMMAND
@@ -231,6 +235,9 @@ end
 def process(args)
   cmd = args[0]
   case cmd
+  when 'version', '--version'
+    puts "#{PROGRAM_NAME} v#{VERSION}"
+    true
   when 'help'
     help
     true

--- a/dist/opt/flight/libexec/flight-starter/config
+++ b/dist/opt/flight/libexec/flight-starter/config
@@ -39,6 +39,7 @@ end
 
 VERSION = '1.1.0'
 PROGRAM_NAME = ENV.fetch('FLIGHT_PROGRAM_NAME','config')
+UNKNOWN_SETTING = {}.freeze
 
 def help
   begin
@@ -90,7 +91,7 @@ def read_value(k)
   if meta = (value_map[category][key] rescue nil)
     get_value_for(meta)
   else
-    nil
+    UNKNOWN_SETTING
   end
 end
 
@@ -235,12 +236,15 @@ def process(args)
     true
   when 'get'
     if args[1].nil?
-      $stderr.puts "#{PROGRAM_NAME}: unknown setting: '#{args[1]}'"
-    elsif val = read_value(args[1])
-      puts val
-      true
+      $stderr.puts "#{PROGRAM_NAME}: setting not given"
     else
-      $stderr.puts "#{PROGRAM_NAME}: unknown setting: '#{args[1]}'"
+      val = read_value(args[1])
+      if val == UNKNOWN_SETTING
+        $stderr.puts "#{PROGRAM_NAME}: unknown setting: '#{args[1]}'"
+      else
+        puts val unless val.nil?
+        true
+      end
     end
   when 'set'
     if set_value(args[1],args[2])


### PR DESCRIPTION
Previously, `config get NAME` would exit `1` if `NAME` was not a valid setting or if it was unset or set to the empty string.

Now, it exits `1` only if it is an invalid setting.  If it is unset or set to the empty string it exits `0` and prints nothing.

Code that previously used the exit status to determine if it was unset will need to be updated to check the output against the empty string.  E.g. the following code will need updating as shown below.

```sh
domain=$(flight config get web-suite.domain)
if [ $? -eq 0 ]; then
  # The domain has been set to a non-empty value
  :
fi
```

```sh
domain=$(flight config get web-suite.domain)
if [ $? -eq 0 -a "$domain" != "" ]; then
  # The domain has been set to a non-empty value
  :
fi
```

The version of `flight config` has been bumped to 2.0.0 and a `--version` flag has been added to `flight config`.