### PR TITLE
Correct variable names

### DIFF
--- a/dist/opt/flight/etc/setup-sshkey.rc
+++ b/dist/opt/flight/etc/setup-sshkey.rc
@@ -24,8 +24,8 @@
 # For more information on Flight Starter, please visit:
 # https://github.com/openflighthpc/flight-starter
 #==============================================================================
-cw_SSH_LOWEST_UID=500
-cw_SSH_SKIP_USERS="root"
-cw_SSH_KEYNAME=id_alcescluster
-cw_SSH_DIR="$HOME/.ssh"
-cw_SSH_LOG="$HOME/.cache/flight/setup-sshkey.log"
+flight_SSH_LOWEST_UID=500
+flight_SSH_SKIP_USERS="root"
+flight_SSH_KEYNAME=id_alcescluster
+flight_SSH_DIR="$HOME/.ssh"
+flight_SSH_LOG="$HOME/.cache/flight/setup-sshkey.log"


### PR DESCRIPTION
Old clusterware variable naming convention being used mean it's not possible to override ssh setupkey behaviour. 

If this looks good to merge then a new release of `flight-starter` would be appreciated (although any other magic needed for version bumping is beyond me!) 