### PR TITLE
Disable Flight Starter for non-bash shells

### DIFF
--- a/dist/etc/profile.d/zz-flight-starter.sh
+++ b/dist/etc/profile.d/zz-flight-starter.sh
@@ -24,6 +24,10 @@
 # For more information on Flight Starter, please visit:
 # https://github.com/openflighthpc/flight-starter
 #==============================================================================
+if [ -z "$BASH_VERSION" ]; then
+  return
+fi
+
 export flight_ROOT=${flight_ROOT:-/opt/flight}
 # record the value of nounset
 if [ "${-#*u}" != "$-" ]; then


### PR DESCRIPTION
This PR adds a change to halt the entrypoint script early if the user is executing it in a shell other than Bash.