### PR TITLE
Improve Prompt & Introduce Cluster Status Banner Message

### DIFF
--- a/dist/opt/flight/etc/banner/banner.d/10-tips.sh
+++ b/dist/opt/flight/etc/banner/banner.d/10-tips.sh
@@ -46,6 +46,12 @@
       echo ""
       unset flight_TIP_break
     fi
+    if [ "$flight_TIP_root" == "true" ]; then
+      if ! sudo -ln /bin/bash &>/dev/null ; then
+        continue
+      fi
+      unset flight_TIP_root
+    fi
     if [ -n "$flight_TIP_command" -a -n "$flight_TIP_synopsis" ]; then
       printf "%-${len}s - %s\n" \
              "${bold}${white}'${bgblue}$flight_TIP_command${clr}${bold}${white}'${clr}" \

--- a/dist/opt/flight/etc/banner/banner.d/10-tips.sh
+++ b/dist/opt/flight/etc/banner/banner.d/10-tips.sh
@@ -25,6 +25,9 @@
 # https://github.com/openflighthpc/flight-starter
 #==============================================================================
 (
+  if [[ ${flight_STARTER_tips:-enabled} != "enabled" ]] ; then
+    exit
+  fi
   bold="$(tput bold)"
   clr="$(tput sgr0)"
   if [[ $TERM =~ "256color" ]]; then

--- a/dist/opt/flight/etc/banner/banner.d/10-tips.sh
+++ b/dist/opt/flight/etc/banner/banner.d/10-tips.sh
@@ -26,7 +26,7 @@
 #==============================================================================
 (
   if [[ ${flight_STARTER_tips:-enabled} != "enabled" ]] ; then
-    exit
+    return
   fi
   bold="$(tput bold)"
   clr="$(tput sgr0)"

--- a/dist/opt/flight/etc/banner/banner.d/20-status.sh
+++ b/dist/opt/flight/etc/banner/banner.d/20-status.sh
@@ -27,18 +27,18 @@
 (
   # Only show for users with sudo
   if ! sudo -l -n sudo >/dev/null 2>&1 ; then
-    exit
+    return
   fi
 
   # Don't show unless enabled with 'flight set status on'
   if [[ ${flight_STARTER_status:-'disabled'} != "enabled" ]] ; then
-    exit
+    return
   fi
 
   # Skip if flight-profile and flight-hunter are not present
   if ! [[ -f ${flight_ROOT}/libexec/commands/profile && -f ${flight_ROOT}/libexec/commands/hunter ]] ; then
     echo "Cluster Status: Not showing (Profile & Hunter not found)"
-    exit
+    return
   fi
 
   # Set formatting

--- a/dist/opt/flight/etc/banner/banner.d/20-status.sh
+++ b/dist/opt/flight/etc/banner/banner.d/20-status.sh
@@ -1,0 +1,73 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Starter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Starter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Starter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Starter, please visit:
+# https://github.com/openflighthpc/flight-starter
+#==============================================================================
+(
+  # Only show for users with sudo
+  if ! sudo -l -n sudo >/dev/null 2>&1 ; then
+    exit
+  fi
+
+  # Don't show unless enabled with 'flight set status on'
+  if [[ ${flight_STARTER_status:-'disabled'} != "enabled" ]] ; then
+    exit
+  fi
+
+  # Set formatting
+  bold="$(tput bold)"
+  clr="$(tput sgr0)"
+  if [[ $TERM =~ "256color" ]]; then
+    white="$(tput setaf 7)"
+    bgblue="$(tput setab 68)"
+    bgred="$(tput setab 210)"
+    bgorange="$(tput setab 136)"
+    bggreen="$(tput setab 64)"
+  fi
+  echo -e "CLUSTER STATUS:\n"
+  shopt -s nullglob
+
+  # Hunter info
+  printf "${bold}${white}${bgblue}Hunted Nodes$flight_TIP_command${clr}${bold}${white}${clr}\n"
+  printf "  ${bold}${white}${bggreen}Parsed:$flight_TIP_command${clr}${bold}${white}${clr}\
+    $(ls ${flight_ROOT}/opt/hunter/var/parsed/ | wc -l)\
+    ${bold}${white}${bgorange}Buffer:$flight_TIP_command${clr}${bold}${white}${clr}\
+    $(ls ${flight_ROOT}/opt/hunter/var/buffer/ | wc -l)\n"
+  echo ""
+
+  # Profile info
+  finished="$(grep exit_status ${flight_ROOT}/opt/profile/var/inventory/* |awk '{print $2}' |grep -v '^$')"
+  completed_nodes="$(echo "$finished" |grep 0 |grep -v '^$' -c )"
+  failed_nodes="$(echo "$finished" |grep -v 0 |grep -v '^$' -c )"
+  applying_nodes="$(grep deployment_pid ${flight_ROOT}/opt/profile/var/inventory/* |awk '{print $2}' |grep -v '^$' |wc -l)"
+  printf "${bold}${white}${bgblue}Configured Nodes$flight_TIP_command${clr}${bold}${white}${clr}\n"
+  printf "  ${bold}${white}${bggreen}Completed:$flight_TIP_command${clr}${bold}${white}${clr}\
+    $completed_nodes\
+    ${bold}${white}${bgorange}Applying:$flight_TIP_command${clr}${bold}${white}${clr}\
+    $applying_nodes\
+    ${bold}${white}${bgred}Failed:$flight_TIP_command${clr}${bold}${white}${clr}\
+    $failed_nodes\n"
+  shopt -u nullglob
+  echo ""
+)

--- a/dist/opt/flight/etc/banner/banner.d/20-status.sh
+++ b/dist/opt/flight/etc/banner/banner.d/20-status.sh
@@ -1,5 +1,5 @@
 #==============================================================================
-# Copyright (C) 2019-present Alces Flight Ltd.
+# Copyright (C) 2024-present Alces Flight Ltd.
 #
 # This file is part of Flight Starter.
 #

--- a/dist/opt/flight/etc/banner/banner.d/20-status.sh
+++ b/dist/opt/flight/etc/banner/banner.d/20-status.sh
@@ -63,10 +63,10 @@
   echo ""
 
   # Profile info
-  finished="$(grep exit_status ${flight_ROOT}/opt/profile/var/inventory/* |awk '{print $2}' |grep -v '^$')"
+  finished="$(grep -R exit_status ${flight_ROOT}/opt/profile/var/inventory/ |awk '{print $2}' |grep -v '^$')"
   completed_nodes="$(echo "$finished" |grep '^0$' |grep -v '^$' -c )"
   failed_nodes="$(echo "$finished" |grep -v '^0$' |grep -v '^$' -c )"
-  applying_nodes="$(grep deployment_pid ${flight_ROOT}/opt/profile/var/inventory/* |awk '{print $2}' |grep -v '^$' -c)"
+  applying_nodes="$(grep -R deployment_pid ${flight_ROOT}/opt/profile/var/inventory/ |awk '{print $2}' |grep -v '^$' -c)"
   printf "${bold}${white}${bgblue}Configured Nodes$flight_TIP_command${clr}${bold}${white}${clr}\n"
   printf "  ${bold}${white}${bggreen}Completed:$flight_TIP_command${clr}${bold}${white}${clr}\
     $completed_nodes\

--- a/dist/opt/flight/etc/banner/banner.d/20-status.sh
+++ b/dist/opt/flight/etc/banner/banner.d/20-status.sh
@@ -35,6 +35,12 @@
     exit
   fi
 
+  # Skip if flight-profile and flight-hunter are not present
+  if ! [[ -f ${flight_ROOT}/libexec/commands/profile && -f ${flight_ROOT}/libexec/commands/hunter ]] ; then
+    echo "Cluster Status: Not showing (Profile & Hunter not found)"
+    exit
+  fi
+
   # Set formatting
   bold="$(tput bold)"
   clr="$(tput sgr0)"

--- a/dist/opt/flight/etc/banner/banner.d/20-status.sh
+++ b/dist/opt/flight/etc/banner/banner.d/20-status.sh
@@ -64,9 +64,9 @@
 
   # Profile info
   finished="$(grep exit_status ${flight_ROOT}/opt/profile/var/inventory/* |awk '{print $2}' |grep -v '^$')"
-  completed_nodes="$(echo "$finished" |grep 0 |grep -v '^$' -c )"
-  failed_nodes="$(echo "$finished" |grep -v 0 |grep -v '^$' -c )"
-  applying_nodes="$(grep deployment_pid ${flight_ROOT}/opt/profile/var/inventory/* |awk '{print $2}' |grep -v '^$' |wc -l)"
+  completed_nodes="$(echo "$finished" |grep '^0$' |grep -v '^$' -c )"
+  failed_nodes="$(echo "$finished" |grep -v '^0$' |grep -v '^$' -c )"
+  applying_nodes="$(grep deployment_pid ${flight_ROOT}/opt/profile/var/inventory/* |awk '{print $2}' |grep -v '^$' -c)"
   printf "${bold}${white}${bgblue}Configured Nodes$flight_TIP_command${clr}${bold}${white}${clr}\n"
   printf "  ${bold}${white}${bggreen}Completed:$flight_TIP_command${clr}${bold}${white}${clr}\
     $completed_nodes\

--- a/dist/opt/flight/etc/banner/tips.d/02-set.rc
+++ b/dist/opt/flight/etc/banner/tips.d/02-set.rc
@@ -1,5 +1,5 @@
 #==============================================================================
-# Copyright (C) 2019-present Alces Flight Ltd.
+# Copyright (C) 2024-present Alces Flight Ltd.
 #
 # This file is part of Flight Starter.
 #

--- a/dist/opt/flight/etc/banner/tips.d/02-set.rc
+++ b/dist/opt/flight/etc/banner/tips.d/02-set.rc
@@ -1,0 +1,28 @@
+#==============================================================================
+# Copyright (C) 2019-present Alces Flight Ltd.
+#
+# This file is part of Flight Starter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Starter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Starter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Starter, please visit:
+# https://github.com/openflighthpc/flight-starter
+#==============================================================================
+flight_TIP_command="flight set"
+flight_TIP_synopsis="change login defaults (see 'flight info' for details)" 

--- a/dist/opt/flight/libexec/commands/info
+++ b/dist/opt/flight/libexec/commands/info
@@ -140,7 +140,7 @@ You may configure the behaviour of ${flight_STARTER_product} on log in to your e
  * To disable ${flight_STARTER_product} command tips in the banner when
    'always' is set to 'on':
 
-     ^flight set hints off}
+     ^flight set tips off}
 
  * To enable ${flight_STARTER_product} cluster status in the banner when
    'always' is set to 'on' (requires flight-profile and flight-hunter):

--- a/dist/opt/flight/libexec/commands/info
+++ b/dist/opt/flight/libexec/commands/info
@@ -137,6 +137,16 @@ You may configure the behaviour of ${flight_STARTER_product} on log in to your e
 
      ^flight set always on}
 
+ * To disable ${flight_STARTER_product} command tips in the banner when
+   'always' is set to 'on':
+
+     ^flight set hints off}
+
+ * To enable ${flight_STARTER_product} cluster status in the banner when
+   'always' is set to 'on' (requires flight-profile and flight-hunter):
+
+     ^flight set status on}
+
 You can toggle these settings 'on' or 'off' at any time.
 
 +== Further help ==}

--- a/dist/opt/flight/libexec/commands/set
+++ b/dist/opt/flight/libexec/commands/set
@@ -133,8 +133,24 @@ case $action in
   DESCRIPTION:
 
     Set the ${flight_STARTER_product} setting <key> to <value>. Valid
-    keys are 'hints', 'welcome', 'secondary' and 'always'. Valid
+    keys are 'hints', 'welcome', 'secondary', 'always', 'tips' and 'status'. Valid
     values are 'on' and 'off'.
+
+    The keys are as follows: 
+
+      hints         Toggle showing of hints to start/enable ${flight_STARTER_product}
+                    system (when 'always' is off) 
+
+      welcome       Toggle showing of welcome to cluster line (when 'always' is off)
+
+      secondary     Toggle running of ${flight_STARTER_product} on secondary shells
+
+      always        Set whether ${flight_STARTER_product} is activated on login 
+
+      tips          Set ${flight_STARTER_product} sub-command tips (when 'always' is on)
+
+      status        Set showing of ${flight_STARTER_product} cluster status
+                    (when 'always' is on)
 
     Specify '--global' option to make the setting apply system-wide
     (requires superuser access).
@@ -165,6 +181,20 @@ EOF
   secondary|secondar|seconda|second|secon|seco|sec|se|s)
     if set_val 'flight_STARTER_secondary' "$2"; then
       echo "${flight_NAME} set: ${flight_STARTER_product} on secondary shells ${state}."
+    else
+      exit 1
+    fi
+    ;;
+  tips|tip|ti|t)
+    if set_val 'flight_STARTER_tips' "$2"; then
+      echo "${flight_NAME} set: ${flight_STARTER_product} banner tips ${state}."
+    else
+      exit 1
+    fi
+    ;;
+  status|statu|stat|sta|st)
+    if set_val 'flight_STARTER_status' "$2"; then
+      echo "${flight_NAME} set: ${flight_STARTER_product} banner cluster status ${state}."
     else
       exit 1
     fi

--- a/dist/opt/flight/libexec/commands/set
+++ b/dist/opt/flight/libexec/commands/set
@@ -139,18 +139,20 @@ case $action in
     The keys are as follows: 
 
       hints         Toggle showing of hints to start/enable ${flight_STARTER_product}
-                    system (when 'always' is off) 
+                    system (in inactive ${flight_STARTER_product} environments) 
 
-      welcome       Toggle showing of welcome to cluster line (when 'always' is off)
+      welcome       Toggle showing of welcome to cluster line (in inactive
+                    ${flight_STARTER_product} environments)
 
       secondary     Toggle running of ${flight_STARTER_product} on secondary shells
 
       always        Set whether ${flight_STARTER_product} is activated on login 
 
-      tips          Set ${flight_STARTER_product} sub-command tips (when 'always' is on)
+      tips          Set ${flight_STARTER_product} sub-command tips (in active 
+                    ${flight_STARTER_product} environments)
 
       status        Set showing of ${flight_STARTER_product} cluster status
-                    (when 'always' is on)
+                    (in active ${flight_STARTER_product} environments)
 
     Specify '--global' option to make the setting apply system-wide
     (requires superuser access).


### PR DESCRIPTION
This PR makes a few changes: 

- Adds options to 'set' for toggling active banner parts (currently for the 'tips' and 'status' sections)
    - Adds corresponding information to 'info'
- Introduces 'status' banner part
    - This is useful for Flight Solo (and any other systems utilising Flight Profile & Flight Hunter)
    - Disabled by default
- Adds flight set to the active banner command tips
- Expands flight set help page to give similar info to flight info on the different keys that can be set (may be slightly redundant but I did it before realising info gives some of this info (and more), I think it's worth keeping though) 

An example of what the prompt can look like when cluster status is enabled 
<img width="580" alt="Screenshot 2024-01-16 at 17 52 02" src="https://github.com/openflighthpc/flight-starter/assets/27725639/3807c6cc-08b1-4354-8887-347386cae558">
