### PR TITLE
2024.1 Enhancements

### DIFF
--- a/dist/opt/flight/etc/banner/banner.d/10-tips.sh
+++ b/dist/opt/flight/etc/banner/banner.d/10-tips.sh
@@ -46,6 +46,12 @@
       echo ""
       unset flight_TIP_break
     fi
+    if [ "$flight_TIP_root" == "true" ]; then
+      if ! sudo -ln /bin/bash &>/dev/null ; then
+        continue
+      fi
+      unset flight_TIP_root
+    fi
     if [ -n "$flight_TIP_command" -a -n "$flight_TIP_synopsis" ]; then
       printf "%-${len}s - %s\n" \
              "${bold}${white}'${bgblue}$flight_TIP_command${clr}${bold}${white}'${clr}" \

--- a/dist/opt/flight/etc/banner/banner.d/10-tips.sh
+++ b/dist/opt/flight/etc/banner/banner.d/10-tips.sh
@@ -25,6 +25,9 @@
 # https://github.com/openflighthpc/flight-starter
 #==============================================================================
 (
+  if [[ ${flight_TIPS_show:-enabled} != "enabled" ]] ; then
+    return
+  fi
   bold="$(tput bold)"
   clr="$(tput sgr0)"
   if [[ $TERM =~ "256color" ]]; then

--- a/dist/opt/flight/etc/banner/tips.d/02-set.rc
+++ b/dist/opt/flight/etc/banner/tips.d/02-set.rc
@@ -1,0 +1,28 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Flight Starter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Starter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Starter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Starter, please visit:
+# https://github.com/openflighthpc/flight-starter
+#==============================================================================
+flight_TIP_command="flight set"
+flight_TIP_synopsis="change login defaults (see 'flight info' for details)" 

--- a/dist/opt/flight/etc/settings.d/tips.rc
+++ b/dist/opt/flight/etc/settings.d/tips.rc
@@ -1,0 +1,8 @@
+flight_SET_key=flight_TIPS_show
+flight_SET_desc="${flight_STARTER_product} banner tips"
+flight_SET_info="
+ * To disable ${flight_STARTER_product} sub-command tips (in
+   active ${flight_STARTER_product} environments)
+
+     ^flight set tips off}
+"

--- a/dist/opt/flight/etc/settings.d/tips.rc
+++ b/dist/opt/flight/etc/settings.d/tips.rc
@@ -1,3 +1,29 @@
+#==============================================================================
+# Copyright (C) 2024-present Alces Flight Ltd.
+#
+# This file is part of Flight Starter.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Starter is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Starter. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Starter, please visit:
+# https://github.com/openflighthpc/flight-starter
+#==============================================================================
 flight_SET_key=flight_TIPS_show
 flight_SET_desc="${flight_STARTER_product} banner tips"
 flight_SET_info="

--- a/dist/opt/flight/libexec/commands/info
+++ b/dist/opt/flight/libexec/commands/info
@@ -97,6 +97,14 @@ case $action in
 EOF
     ;;
   *)
+    shopt -s nullglob
+    _additional="$(echo)"
+    for a in "${flight_ROOT}"/etc/settings.d/*.rc; do
+	. "$a"
+	_additional="${_additional}${flight_SET_info}$(echo)"
+    done
+    shopt -u nullglob
+
     export LESS=${LESS:--FRX}
     (
       cat <<EOF
@@ -136,7 +144,7 @@ You may configure the behaviour of ${flight_STARTER_product} on log in to your e
    in, execute:
 
      ^flight set always on}
-
+$_additional
 You can toggle these settings 'on' or 'off' at any time.
 
 +== Further help ==}

--- a/dist/opt/flight/libexec/commands/set
+++ b/dist/opt/flight/libexec/commands/set
@@ -125,6 +125,12 @@ setup
 
 case $action in
   help|hel|he|h|--help|-h)
+    shopt -s nullglob
+    _additional=""
+    for a in "${flight_ROOT}"/etc/settings.d/*.rc; do
+	_additional="${_additional}, '$(basename "$a" .rc)'"
+    done
+    shopt -u nullglob
     cat <<EOF
   SYNOPSIS:
 
@@ -132,9 +138,11 @@ case $action in
 
   DESCRIPTION:
 
-    Set the ${flight_STARTER_product} setting <key> to <value>. Valid
-    keys are 'hints', 'welcome', 'secondary' and 'always'. Valid
-    values are 'on' and 'off'.
+    Set the ${flight_STARTER_product} setting <key> to <value>. Valid keys are:
+
+      'hints', 'welcome', 'secondary'${_additional} and 'always'
+
+    Valid values are 'on' and 'off'.
 
     Specify '--global' option to make the setting apply system-wide
     (requires superuser access).
@@ -174,7 +182,16 @@ EOF
     exit 1
     ;;
   *)
+    if [ -f "${flight_ROOT}"/etc/settings.d/$action.rc ]; then
+	. "${flight_ROOT}"/etc/settings.d/$action.rc
+	if set_val "${flight_SET_key}" "$2"; then
+	    echo "${flight_NAME} set: ${flight_SET_desc} ${state}."
+	else
+	    exit 1
+	fi
+    else
     echo "${flight_NAME} set: unrecognized setting"
     exit 1
+    fi
     ;;
 esac

--- a/dist/opt/flight/libexec/commands/set
+++ b/dist/opt/flight/libexec/commands/set
@@ -147,6 +147,8 @@ case $action in
     Specify '--global' option to make the setting apply system-wide
     (requires superuser access).
 
+    For more information see '$flight_NAME info'.
+
 EOF
     ;;
   hints|hint|hin|hi|h)


### PR DESCRIPTION
This PR adds some enhancements to Flight Start to support additional configuration operations that will be introduced in Flight Solo 2024.1.

- Add plugin system for `flight set`
    - This allows other tools to add user-level configuration options 
    - Additionally the plugin files allow for adding command description to `flight info`
- Adds 'set' plugin for the tips banner
    - Defaults to enabled (via variable check in `10-tips.sh`) 
 - Adds support for "root only" tips 
     - Some flight tools are only shown in `flight help` list to users with sudo access, this allows flagging tips to only appear for users that have similar access via `flight_TIP_root` in relevant `banner/tips.d/*.rc` files
- Adds `flight set` to the tips list 